### PR TITLE
Fix date to use Taipei timezone

### DIFF
--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -22,13 +22,13 @@ jobs:
         run: |
           IFS=$'\n' read -r -a lessons <<< "$LESSONS"
           total=${#lessons[@]}
-          day_idx=$(( $(date -u +%s) / 86400 % total ))
+          day_idx=$(( $(TZ=Asia/Taipei date +%s) / 86400 % total ))
           title="${lessons[$day_idx]}"
           echo "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" > encode.py
           url_encoded=$(python3 encode.py "$title")
           link="https://zh.wikisource.org/zh-hant/${url_encoded}"
           out_dir="docs"
-          out_file="${out_dir}/$(date -u +%F).html"
+          out_file="${out_dir}/$(TZ=Asia/Taipei date +%F).html"
           mkdir -p "$out_dir"
           printf '<!DOCTYPE html>\n<html lang="zh-Hant">\n<head>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0;url=%s">\n<title>跳轉中...</title>\n</head>\n<body>\n如果沒有自動跳轉，請點擊 <a href="%s">%s</a>\n</body>\n</html>\n' "$link" "$link" "$title" > "$out_file"
           echo "🔗 生成：$out_file → $link"
@@ -39,5 +39,5 @@ jobs:
           git config user.name  github-actions
           git config user.email actions@github.com
           git add docs
-          git commit -m "docs: add lesson link $(date -u +%F)" || echo "Nothing to commit"
+          git commit -m "docs: add lesson link $(TZ=Asia/Taipei date +%F)" || echo "Nothing to commit"
           git push


### PR DESCRIPTION
## Summary
- use Asia/Taipei timezone when generating lesson links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ed921570c8331a4873766a98d141e