### PR TITLE
Fix LESSONS array handling

### DIFF
--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Generate Wikisource link
         shell: bash
         run: |
-          IFS=$'\n' read -r -a lessons <<< "$LESSONS"
+          mapfile -t lessons <<< "$LESSONS"
           total=${#lessons[@]}
           # 以一年中的第幾天決定課文，讓每天都不同，每年循環
           day_of_year=$(TZ=Asia/Taipei date +%j)


### PR DESCRIPTION
## Summary
- correctly read multiple lessons into an array using `mapfile`

## Testing
- `grep -n "mapfile" -n .github/workflows/link-only.yml`


------
https://chatgpt.com/codex/tasks/task_e_6852dd56d2ec8331895861c57577be6c