### PR TITLE
Update workflow to query perplexity

### DIFF
--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -17,7 +17,7 @@ jobs:
         國文 第十課 木蘭詩
     steps:
       - uses: actions/checkout@v4
-      - name: Generate Wikisource link
+      - name: Generate Perplexity lesson
         shell: bash
         run: |
           mapfile -t lessons <<< "$LESSONS"
@@ -27,12 +27,17 @@ jobs:
           day_idx=$(( (10#$day_of_year - 1) % total ))
           title="${lessons[$day_idx]}"
           echo "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" > encode.py
-          url_encoded=$(python3 encode.py "$title")
-          link="https://zh.wikisource.org/zh-hant/${url_encoded}"
+          prompt="請根據附檔的課文教學重點格式，提供一篇詳細的課文學習教材，內容盡可能的詳細，題目如下: ${title}"
+          url_encoded=$(python3 encode.py "$prompt")
+          link="https://www.perplexity.ai/search?q=${url_encoded}"
           out_dir="docs"
           out_file="${out_dir}/$(TZ=Asia/Taipei date +%F).html"
           mkdir -p "$out_dir"
-          printf '<!DOCTYPE html>\n<html lang="zh-Hant">\n<head>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0;url=%s">\n<title>跳轉中...</title>\n</head>\n<body>\n如果沒有自動跳轉，請點擊 <a href="%s">%s</a>\n</body>\n</html>\n' "$link" "$link" "$title" > "$out_file"
+          if response=$(curl -fsSL "$link"); then
+            echo "$response" > "$out_file"
+          else
+            printf '<!DOCTYPE html>\n<html lang="zh-Hant">\n<head>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0;url=%s">\n<title>跳轉中...</title>\n</head>\n<body>\n如果沒有自動跳轉，請點擊 <a href="%s">%s</a>\n</body>\n</html>\n' "$link" "$link" "$title" > "$out_file"
+          fi
           echo "🔗 生成：$out_file → $link"
       - name: Commit and push to Pages
         env:


### PR DESCRIPTION
## Summary
- switch the daily link generator to perplexity.ai
- fetch the generated page when possible and fallback to a link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c99e48888331a1b2cd8c3230fec4