### PR TITLE
Fix fallback for lesson fetch

### DIFF
--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -16,6 +16,7 @@ jobs:
         id: fetch
         run: |
           url="https://www.learnmode.net/course/638520/content"
+          # Use a User-Agent header so requests are less likely to be blocked
           set -o pipefail
           tmp=$(mktemp)
           if ! curl -fsSL -A 'Mozilla/5.0' "$url" 2>"$tmp" | \

--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -18,7 +18,7 @@ jobs:
           url="https://www.learnmode.net/course/638520/content"
           set -o pipefail
           tmp=$(mktemp)
-          if ! curl -fsSL "$url" 2>"$tmp" | \
+          if ! curl -fsSL -A 'Mozilla/5.0' "$url" 2>"$tmp" | \
             grep -oE '【[0-9]+-[0-9]+】[^<]+' > lessons.txt
           then
             echo "scraping failed: curl=${PIPESTATUS[0]} grep=${PIPESTATUS[1]}"

--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -10,13 +10,28 @@ on:
 jobs:
   generate-link:
     runs-on: ubuntu-latest
-    env:
-      LESSONS: |
-        國文 第八課 記承天寺夜遊
-        國文 第九課 桃花源記
-        國文 第十課 木蘭詩
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch lesson titles
+        id: fetch
+        run: |
+          url="https://www.learnmode.net/course/638520/content"
+          set -o pipefail
+          tmp=$(mktemp)
+          if ! curl -fsSL "$url" 2>"$tmp" | \
+            grep -oE '【[0-9]+-[0-9]+】[^<]+' > lessons.txt
+          then
+            echo "scraping failed: curl=${PIPESTATUS[0]} grep=${PIPESTATUS[1]}"
+            cat "$tmp"
+            printf '%s\n' \
+              '國文 第八課 記承天寺夜遊' \
+              '國文 第九課 桃花源記' \
+              '國文 第十課 木蘭詩' > lessons.txt
+          fi
+          rm -f "$tmp"
+          echo 'LESSONS<<EOF' >> "$GITHUB_ENV"
+          cat lessons.txt >> "$GITHUB_ENV"
+          echo 'EOF' >> "$GITHUB_ENV"
       - name: Generate Perplexity lesson
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- handle curl failure when scraping lesson titles
- log exit codes and curl errors when scraping fails

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685614df07cc8331bc37fd239a1b6647