### PR TITLE
Fix fallback for lesson fetch

### DIFF
--- a/.github/workflows/link-only.yml
+++ b/.github/workflows/link-only.yml
@@ -10,13 +10,32 @@ on:
 jobs:
   generate-link:
     runs-on: ubuntu-latest
-    env:
-      LESSONS: |
-        國文 第八課 記承天寺夜遊
-        國文 第九課 桃花源記
-        國文 第十課 木蘭詩
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch lesson titles
+        id: fetch
+        run: |
+          url="https://www.learnmode.net/course/638520/content"
+          # Use a User-Agent header so requests are less likely to be blocked
+          tmp=$(mktemp)
+          curl -fsSL -A 'Mozilla/5.0' "$url" -o "$tmp"
+          curl_status=$?
+          grep -oE '【[0-9]+-[0-9]+】[^<]+' "$tmp" > lessons.txt
+          grep_status=$?
+          if [ $curl_status -ne 0 ] || [ $grep_status -ne 0 ] || [ ! -s lessons.txt ]; then
+            echo "scraping failed: curl=$curl_status grep=$grep_status"
+            cat "$tmp"
+            printf '%s\n' \
+              '國文 第八課 記承天寺夜遊' \
+              '國文 第九課 桃花源記' \
+              '國文 第十課 木蘭詩' > lessons.txt
+          fi
+          rm -f "$tmp"
+          {
+            echo 'LESSONS<<EOF'
+            cat lessons.txt
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
       - name: Generate Perplexity lesson
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in workflow
- clarify why we send a User-Agent header
- handle scraping failure gracefully and avoid workflow errors

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685614df07cc8331bc37fd239a1b6647